### PR TITLE
 Make '--all' work correctly in gathersymbols.py

### DIFF
--- a/scrapesymbols/gathersymbols.py
+++ b/scrapesymbols/gathersymbols.py
@@ -40,7 +40,7 @@ def should_process(f, platform=sys.platform):
         '''
         try:
             filetype = subprocess.check_output(['file', '-Lb', f])
-        except CalledProcessError:
+        except subprocess.CalledProcessError:
             return False
         '''Skip kernel extensions'''
         if filetype.find('kext bundle') != -1:

--- a/scrapesymbols/gathersymbols.py
+++ b/scrapesymbols/gathersymbols.py
@@ -18,7 +18,8 @@ if sys.platform == 'darwin':
     SYSTEM_DIRS = [
         '/usr/lib',
         '/System/Library/Frameworks',
-        '/System/Library/PrivateFrameworks'
+        '/System/Library/PrivateFrameworks',
+        '/System/Library/Extensions'
     ]
 else:
     SYSTEM_DIRS = [
@@ -31,7 +32,11 @@ MISSING_SYMBOLS_URL = 'https://crash-analysis.mozilla.com/crash_analysis/{date}/
 def should_process(f, platform=sys.platform):
     '''Determine if a file is a platform binary'''
     if platform == 'darwin':
-        return subprocess.check_output(['file', '-Lb', f]).startswith('Mach-O')
+        filetype = subprocess.check_output(['file', '-Lb', f])
+        '''Skip kernel extensions'''
+        if filetype.find('kext bundle') != -1:
+            return False
+        return filetype.startswith('Mach-O')
     else:
         return subprocess.check_output(['file', '-Lb', f]).startswith('ELF')
     return False

--- a/scrapesymbols/gathersymbols.py
+++ b/scrapesymbols/gathersymbols.py
@@ -32,7 +32,16 @@ MISSING_SYMBOLS_URL = 'https://crash-analysis.mozilla.com/crash_analysis/{date}/
 def should_process(f, platform=sys.platform):
     '''Determine if a file is a platform binary'''
     if platform == 'darwin':
-        filetype = subprocess.check_output(['file', '-Lb', f])
+        '''
+        The 'file' command can error out. One example is "illegal byte
+        sequence" on a Japanese language UTF8 text file. So we must wrap the
+        command in a try/except block to prevent the script from terminating
+        prematurely when this happens.
+        '''
+        try:
+            filetype = subprocess.check_output(['file', '-Lb', f])
+        except CalledProcessError:
+            return False
         '''Skip kernel extensions'''
         if filetype.find('kext bundle') != -1:
             return False

--- a/scrapesymbols/gathersymbols.py
+++ b/scrapesymbols/gathersymbols.py
@@ -43,7 +43,7 @@ def should_process(f, platform=sys.platform):
         except subprocess.CalledProcessError:
             return False
         '''Skip kernel extensions'''
-        if filetype.find('kext bundle') != -1:
+        if 'kext bundle' in filetype:
             return False
         return filetype.startswith('Mach-O')
     else:


### PR DESCRIPTION
The server at crash-analysis.mozilla.com has long vanished. In any case, even with --all, the current version of this script only gathers symbols that aren't already on the symbol server. "--all" should really mean "all" -- when this is specified the script shouldn't check that a given set of symbols is already on the server. Only when "--all" isn't specified should the script check.